### PR TITLE
workaround for small pages load

### DIFF
--- a/example.html
+++ b/example.html
@@ -1,0 +1,7 @@
+<script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
+<script src="https://raw.githack.com/alrusdi/jquery-plugin-query-object/master/jquery.query-object.js"></script>
+
+<script>
+var section = $.query.get('section');
+document.write(section);
+</script>

--- a/scripts/content_script.js
+++ b/scripts/content_script.js
@@ -10,7 +10,7 @@ chrome.storage.sync.get("toggle",function(data){
 			if(location.href.search("dummy")!=-1){
 				// hack for frame busting
 				loc = location.href;
-				if(loc.indexOf('e32a5ec9c99')>=0 && loc.search('a0def12bce')==-1)	
+				if(loc.indexOf('e32a5ec9c99')>=0 && loc.search('a0def12bce')==-1)
 				{
 					setTimeout(function(){
 						if((Object.prototype.e32a5ec9c99 == "ddcb362f1d60"))
@@ -40,22 +40,22 @@ chrome.storage.sync.get("toggle",function(data){
 					location = url.href;
 				}
 			}
+
 			window.onload = function(){
 				if((Object.prototype.e32a5ec9c99 == "ddcb362f1d60"  || Object.prototype.a0def12bce == "ddcb362f1d60")){
 						console.log(`%c--------------------Found one------------------\n${location.href}`, `color:red`);
 						logger(location.href);
 				}
-
-				var timerID = setInterval(function() {
-					if((Object.prototype.e32a5ec9c99 == "ddcb362f1d60" || Object.prototype.a0def12bce == "ddcb362f1d60")){
-						console.log(`%c--------------------Found one------------------\n${location.href}`, `color:red`);
-						logger(location.href);
-						clearInterval(timerID);
-
-					}	
-				}, 10 * 1000); 
-
 			}
+
+			var timerID = setInterval(function() {
+				if((Object.prototype.e32a5ec9c99 == "ddcb362f1d60" || Object.prototype.a0def12bce == "ddcb362f1d60")){
+					console.log(`%c--------------------Found one------------------\n${location.href}`, `color:red`);
+					logger(location.href);
+					clearInterval(timerID);
+
+				}
+			}, 10 * 1000);
 		}
 		if(window.name.search("ppdeadbeef")==-1){
 			var iframe = document.createElement('iframe');


### PR DESCRIPTION
On small pages without much javascript, the page would load (triggering `onload`) before the `content_script.js` would get a chance to be injected. But the injected javascript would trigger only at `window.onload`. There was a small chance of missing some results.

My proposed solution is to move the `setInterval` part outside the `onload` function. This way, the catch-all function will get triggered.